### PR TITLE
fix: remove npm path package dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "npm-java-runner",
       "version": "1.0.1",
       "license": "Apache 2",
-      "dependencies": {
-        "path": "^0.12.7"
-      },
       "devDependencies": {
         "@types/glob": "^7.1.1",
         "@types/jest": "^25.2.1",
@@ -201,11 +198,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
     "node_modules/jest-diff": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
@@ -236,15 +228,6 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "node_modules/prettier": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
@@ -270,14 +253,6 @@
       },
       "engines": {
         "node": ">= 8.3"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/react-is": {
@@ -353,14 +328,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dependencies": {
-        "inherits": "2.0.3"
       }
     },
     "node_modules/yn": {
@@ -528,11 +495,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
     "jest-diff": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
@@ -557,15 +519,6 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "prettier": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
@@ -583,11 +536,6 @@
         "ansi-styles": "^4.0.0",
         "react-is": "^16.12.0"
       }
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "react-is": {
       "version": "16.13.1",
@@ -638,14 +586,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
       "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
-      }
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "format": "prettier --write .",
     "release": "npm run build && npm version patch && npm publish && git push --follow-tags"
   },
-  "dependencies": {
-    "path": "^0.12.7"
-  },
   "devDependencies": {
     "@types/glob": "^7.1.1",
     "@types/jest": "^25.2.1",


### PR DESCRIPTION
Rely on builtin path module from node itself instead of referencing the npm path package.

fixes #1 

